### PR TITLE
Pull Request for `to_dict` and `count` Methods Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ abarorm.egg-info
 /.txt
 __pycache__/
 **/__pycache__/
+m.py
+./m.py

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - **New in v3.0.0**: Updated return values for methods to improve clarity and usability.
 - **New in v3.0.0**: Enhanced `filter` method now supports `order_by` functionality for result ordering.
 - **New in v3.2.0**: Added `__gte` and `__lte` functionality in the filter section.
+- **New in v4.0.0**: Added `__repr__`, `count`, and `to_dict` methods for easier data manipulation and debugging.
+
 
 
 ## Installation
@@ -138,14 +140,41 @@ To delete a record from the database, use the `delete()` method:
 ```python
 Post.delete(1)  # Delete the post with ID 1
 ```
+### Converting to Dictionary and Counting Records
+After performing operations on the model, you can convert records to dictionaries using the `to_dict()` method and count the number of records using the `count()` method.
 
+#### `to_dict` Method
+The `to_dict()` method converts a model instance into a dictionary, making it easier to manipulate and serialize the data.
 
+**Example:**
+```python
+# Retrieve a post by ID
+post = Post.get(id=1)
 
-### Version 3.0.0
+# Convert the post to a dictionary
+post_dict = post.all().to_dict()
+print(post_dict)
+# Output: [{'id': 1, 'title': 'Godfather', 'create_time': '2024-01-01 12:00:00', ...}]
+```
 
-- **Fixed Table Naming**: Resolved issues related to inconsistent table naming conventions.
-- **Return Values Updated**: Methods now return values that enhance clarity and usability.
-- **Filter Enhancements**: The `filter` method now includes support for `order_by`, allowing for more flexible queries.
+#### `count` Method
+The `count()` method allows you to get the number of records in a model's table.
+
+**Example:**
+```python
+# Count the number of posts in the database
+num_posts = Post.count()
+print(num_posts)  # Output: 10 (if there are 10 posts in the database)
+```
+
+These methods are particularly useful for data manipulation and debugging, as they provide a simple way to view and interact with your database records.
+
+## Version 4.0.0
+
+- **`__repr__` Method**: Added to provide a string representation of model instances for better debugging.
+- **`count` Method**: Added to count the number of records in a model's table.
+- **`to_dict` Method**: Converts model instances into dictionaries for easier manipulation and serialization.
+
 
 **Important for Developers:** When adding new fields to models, they will default to `NULL`. It’s recommended to recreate the database schema after development is complete to ensure fields have appropriate constraints and default values.
 

--- a/abarorm/fields.py
+++ b/abarorm/fields.py
@@ -64,9 +64,17 @@ class EmailField(CharField):
     
     def __init__(self, max_length: int = 255, **kwargs):
         super().__init__(max_length=max_length, **kwargs)
+    
+    def validate(self, value: str):
+        if not re.match(self.EMAIL_REGEX, value):
+            raise ValueError(f"Invalid email address: {value}")
 
 class URLField(CharField):
     URL_REGEX = r'^(https?|ftp)://[^\s/$.?#].[^\s]*$'
     
     def __init__(self, max_length: int = 2048, **kwargs):
         super().__init__(max_length=max_length, **kwargs)
+    
+    def validate(self, value: str):
+        if not re.match(self.URL_REGEX, value):
+            raise ValueError(f"Invalid URL: {value}")

--- a/abarorm/mysql.py
+++ b/abarorm/mysql.py
@@ -19,6 +19,24 @@ class ModelMeta(type):
 class BaseModel(metaclass=ModelMeta):
     table_name = ''
     
+    class QuerySet:
+        def __init__(self, results):
+            self.results = results
+
+        def count(self) -> int:
+            """Returns the number of results."""
+            return len(self.results)
+
+        def to_dict(self) -> List[Dict]:
+            """Returns the results as a list of dictionaries."""
+            return [obj.__dict__ for obj in self.results]
+        def __repr__(self):
+            """Returns a string representation of the QuerySet."""
+            # If there are results, show the first 3 as a sample
+            sample = self.to_dict()[:3]  # Show first 3 items for example
+            return f"<QuerySet(count={self.count()}, first_3_fitst_items={sample})>"  
+
+    
     def __repr__(self):
         # Get all field names and their corresponding values
         field_values = {attr: getattr(self, attr) for attr in self.__class__.__dict__ if isinstance(self.__class__.__dict__[attr], Field)}
@@ -136,7 +154,7 @@ class BaseModel(metaclass=ModelMeta):
         cursor.execute(query)
         results = cursor.fetchall()
         conn.close()
-        return [cls(**dict(zip([c[0] for c in cursor.description], row))) for row in results]
+        return cls.QuerySet([cls(**dict(zip([c[0] for c in cursor.description], row))) for row in results])
 
     @classmethod
     def filter(cls, order_by: Optional[str] = None, **kwargs) -> List['BaseModel']:
@@ -162,7 +180,8 @@ class BaseModel(metaclass=ModelMeta):
         results = cursor.fetchall()
         conn.close()
 
-        return [cls(**dict(zip([c[0] for c in cursor.description], row))) for row in results]
+        return cls.QuerySet([cls(**dict(zip([c[0] for c in cursor.description], row))) for row in results])
+
 
     @classmethod
     def get(cls, **kwargs) -> Optional['BaseModel']:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='abarorm',
-    version='3.2.1',
+    version='4.0.0',
     description='abarorm is a lightweight and easy-to-use Object-Relational Mapping (ORM) library for SQLite & PostgreSQL and MySQL databases in Python. It aims to provide a simple and intuitive interface for managing database models and interactions.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION

#### Overview
This Pull Request introduces two new methods to enhance the usability of the ORM:

1. **`to_dict` Method**:
   - This method converts model instances into dictionaries. It simplifies data manipulation, serialization, and interaction with APIs or external services.
   - It is now easier to work with model data in a dictionary format instead of manually accessing individual fields.

2. **`count` Method**:
   - The `count()` method provides a simple way to get the number of records in a model's table. This is useful for applications that need to display or process the total count of records after filtering or querying.

#### Benefits
- **Flexibility**: Users can now easily work with model data in dictionary format, which is more versatile for tasks like JSON serialization.
- **Efficiency**: The `count()` method allows quick access to the number of records without additional queries or manual counting logic.

#### Example Usage
- **`to_dict`**:
  - This method allows you to convert model instances into dictionaries for easy manipulation or serialization.

- **`count`**:
  - This method provides a count of all records or filtered results in the model's table.

#### Additional Notes
- After implementing these methods, we expect better performance and flexibility when interacting with model data.
- Developers can now easily output model data as dictionaries and count records efficiently, improving the overall usability of the ORM.

Please review and provide feedback. Thank you!