### PR TITLE
mabe bug is fixed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Extract version from setup.py
         id: extract_version
         run: |
-          version=$(python -c "exec(open('setup.py').read()); print(__version__)")
+          version=$(python setup.py --version)
           echo "VERSION=$version" >> $GITHUB_ENV
 
       # Log the extracted version


### PR DESCRIPTION

### Steps to Reproduce:
1. Push changes to the `main` branch.
2. Observe the GitHub Actions workflow failing with the error mentioned above.

### Expected Behavior:
The GitHub Actions workflow should run successfully, extracting the version from the `setup.py` file and publishing the package to PyPI.

### Actual Behavior:
The workflow fails with a YAML syntax error.

### Potential Cause:
This issue may be caused by an indentation error or incorrect formatting in the YAML file, particularly around line 38 where the error is reported.

### Proposed Solution:
- Check the indentation of the YAML file and ensure proper formatting.
- Ensure that the `run` steps under the "Publish to PyPI" section are correctly formatted and properly indented.
- Verify that the syntax of the Python commands for extracting the version from `setup.py` is correct.

### Additional Information:
The following section in the YAML file may need closer inspection:
