### PR TITLE
Implement Bulk Create Method for AbarORM

### DIFF
--- a/abarorm/psql.py
+++ b/abarorm/psql.py
@@ -368,6 +368,56 @@ class BaseModel(metaclass=ModelMeta):
         conn.close()
         return True  # Return True on successful creation
     
+    @classmethod
+    def bulk_create(cls, records: list) -> None:
+        conn = cls.connect()
+        cursor = conn.cursor()
+        
+        if not records:
+            raise ValueError("The records list is empty.")
+
+        columns = []
+        placeholders = []
+        all_values = []
+
+        for record in records:
+            values = []
+            for attr, field in cls.__dict__.items():
+                if isinstance(field, Field):
+                    if isinstance(field, ForeignKey):
+                        if isinstance(record[attr], int):
+                            related_instance = field.to.get(id=record[attr])
+                            if not related_instance:
+                                raise ValueError(f"Related {field.to.__name__} with ID {record[attr]} does not exist.")
+                        elif isinstance(record[attr], field.to):
+                            values.append(record[attr].id) 
+                        else:
+                            raise ValueError(f"Invalid value for foreign key {attr}. Must be an integer ID or instance of {field.to.__name__}.")
+                    
+                    if attr in record:
+                        values.append(record[attr])
+                    elif isinstance(field, DateField) and field.auto_now:
+                        values.append(datetime.datetime.now().strftime('%Y-%m-%d'))
+                    elif isinstance(field, DateField) and field.auto_now_add:
+                        values.append(datetime.datetime.now().strftime('%Y-%m-%d'))
+                    elif isinstance(field, DateTimeField) and field.auto_now:
+                        values.append(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+                    elif isinstance(field, DateTimeField) and field.auto_now_add:
+                        values.append(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+
+            all_values.append(tuple(values))  
+
+        # ایجاد کوئری INSERT دسته‌ای برای چندین رکورد
+        columns = [attr for attr, field in cls.__dict__.items() if isinstance(field, Field)]
+        placeholders = ", ".join(["%s" for _ in columns])
+        query = f"INSERT INTO {cls.table_name} ({', '.join(columns)}) VALUES ({placeholders})"
+        
+        cursor.executemany(query, all_values)  # استفاده از executemany برای وارد کردن دسته‌ای رکوردها
+        conn.commit()
+        conn.close()
+        return True  # بازگشت به True پس از موفقیت
+
+    
     def save(self):
         if hasattr(self, 'id') and self.id:
             data = self.__dict__.copy()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys
 
-__version__ = '5.1.3'
+__version__ = '5.2.0'
 
 
 if '--version' in sys.argv:


### PR DESCRIPTION
## Description  
This pull request introduces the `bulk_create` method for efficient batch insertion of records in AbarORM. The method allows users to insert multiple records at once, reducing database interaction overhead and improving performance.  

## Changes Made  
- **Added** `bulk_create` method to handle batch inserts using `executemany`.  
- **Ensured** that foreign key values are properly validated (either an integer ID or an instance of the related model).  
- **Handled** `auto_now` and `auto_now_add` fields to ensure correct timestamp values during batch insertion.  
- **Included** input validation to prevent empty record lists.  

## Usage Example  
```python
records = [
    {"title": "First Post", "content": "This is the first post."},
    {"title": "Second Post", "content": "This is the second post."},
]

Post.bulk_create(records)
```
## Why This is Needed
- Improves database performance by reducing individual insert operations.
- Provides a more efficient way to insert multiple records at once.
- Aligns with best practices for ORM bulk operations.

## Testing & Verification
- Verified that multiple records are successfully inserted in one query.
- Ensured compatibility with existing create method and foreign key constraints.
- Added input validation to prevent errors with incorrect data types.
