### PR TITLE
43 fix delete method and add filter to queryset in v530

### DIFF
--- a/abarorm/psql.py
+++ b/abarorm/psql.py
@@ -25,6 +25,49 @@ class BaseModel(metaclass=ModelMeta):
             self.total_count = total_count  
             self.page = page  
             self.page_size = page_size
+        
+        def filter(self, **kwargs) -> 'QuerySet':
+            """
+            Filters the QuerySet based on exact matches or comparison operators
+            like __gte, __lte, __gt, __lt, __exact.
+            """
+            if not kwargs:
+                raise ValueError("At least one filter must be provided.")
+
+            filtered_results = []
+
+            for obj in self.results:
+                match = True
+                for key, value in kwargs.items():
+                    if '__' in key:
+                        field_name, op = key.split('__', 1)
+                        field_value = getattr(obj, field_name, None)
+                        if op == 'gte' and not (field_value >= value):
+                            match = False
+                            break
+                        elif op == 'lte' and not (field_value <= value):
+                            match = False
+                            break
+                        elif op == 'gt' and not (field_value > value):
+                            match = False
+                            break
+                        elif op == 'lt' and not (field_value < value):
+                            match = False
+                            break
+                        elif op == 'exact' and not (field_value == value):
+                            match = False
+                            break
+                        else:
+                            raise ValueError(f"Unsupported filter operator: {op}")
+                    else:
+                        if getattr(obj, key, None) != value:
+                            match = False
+                            break
+
+                if match:
+                    filtered_results.append(obj)
+
+            return self.__class__(filtered_results, len(filtered_results), self.page, self.page_size)
 
         def count(self) -> int:
             """Returns the number of results."""

--- a/abarorm/sqlite.py
+++ b/abarorm/sqlite.py
@@ -25,7 +25,49 @@ class BaseModel(metaclass=ModelMeta):
             self.total_count = total_count  
             self.page = page  
             self.page_size = page_size
-        
+        def filter(self, **kwargs) -> 'QuerySet':
+            """
+            Filters the QuerySet based on exact matches of field values.
+            Can handle comparisons like __gte, __lte, __lt, __gt.
+            """
+            if not kwargs:
+                raise ValueError("At least one field and value must be provided for filtering.")
+
+            filtered_results = []
+
+            for obj in self.results:
+                match = True
+                for key, value in kwargs.items():
+                    if '__' in key:
+                        field_name, op = key.split('__', 1)
+                        field_value = getattr(obj, field_name, None)
+                        if op == 'gte' and not (field_value >= value):
+                            match = False
+                            break
+                        elif op == 'lte' and not (field_value <= value):
+                            match = False
+                            break
+                        elif op == 'gt' and not (field_value > value):
+                            match = False
+                            break
+                        elif op == 'lt' and not (field_value < value):
+                            match = False
+                            break
+                        elif op == 'exact' and not (field_value == value):
+                            match = False
+                            break
+                        else:
+                            # Unknown operator
+                            raise ValueError(f"Unsupported filter operator: {op}")
+                    else:
+                        if getattr(obj, key, None) != value:
+                            match = False
+                            break
+
+                if match:
+                    filtered_results.append(obj)
+
+            return self.__class__(filtered_results, len(filtered_results), self.page, self.page_size)
         def count(self) -> int:
             """Returns the number of results."""
             return len(self.results)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys
 
-__version__ = '5.2.2'
+__version__ = '5.3.0'
 
 
 if '--version' in sys.argv:


### PR DESCRIPTION
## [5.3.0] - Major Update

### Added
- **QuerySet `filter` method**: You can now filter in-memory results using operators like `__gte`, `__lte`, `__gt`, `__lt`, and `__exact`. This applies to both SQLite and PostgreSQL models.
- Added `filter` to QuerySet for chaining queries on fetched results.

### Fixed
- **`delete` method bug**: Fixed the bug where `delete` did not properly handle filters in both SQLite and PostgreSQL backends.
- Improved database connection handling and ensured safe deletion with proper row counting.

### Notes
- This is a **breaking change** for the `delete` and QuerySet usage. Make sure to update your code if you rely on the old `delete` method behavior.
- All database operations now use parameterized queries for better safety and compatibility.
