### PR TITLE
AbarORM 5.4.0 - add `related_name` to connection fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - **New in v5.1.0**: Enhanced functionality for better usability for `delete` and `contains` methods.
 - **New in v5.2.0**: Introduced `bulk_create` for efficient batch insertions.
 - **New in v5.3.0**: Added `filter` support to the QuerySet class for in-memory filtering.
+- **New in v5.4.0**: PostgreSQL database creation improved, added `related_name` support for ForeignKeys.
+
 
 
 
@@ -84,7 +86,7 @@ class Post(PostgreSQLModel):
 
     title = psql.CharField(max_length=100, null=False)  # Title of the post, must be unique and not null
     create_time = psql.DateTimeField(auto_now=True)  # Automatically set to current datetime
-    category = psql.ForeignKey(to=Category)  # Foreign key referring to the Category model
+    category = psql.ForeignKey(to=Category, related_name='posts')  # Foreign key referring to the Category model
 ```
 ## CRUD Operations
 Now that you have defined your models, you can perform CRUD operations. Here’s a breakdown of each operation:
@@ -114,6 +116,10 @@ all_posts = Post.all()
 
 # Retrieve a specific post by ID
 post_data = Post.get(id=1)
+
+# Related records via related_name
+cat = Category.get(id=1)
+cat_posts = cat.posts.all()  # Returns a fully functional QuerySet
 ```
 ### Filtering Records
 The `filter()` method allows you to retrieve records based on specified criteria. You can use keyword arguments to filter by field values and sort the results using `order_by`.

--- a/abarorm/fields/psql.py
+++ b/abarorm/fields/psql.py
@@ -43,12 +43,13 @@ class TimeField(Field):
         super().__init__(field_type='TIME', **kwargs)  # PostgreSQL uses TIME for time-only fields
 
 class ForeignKey(Field):
-    def __init__(self, to: Type['BaseModel'], on_delete: str = 'CASCADE', **kwargs):
+    def __init__(self, to: Type['BaseModel'], on_delete: str = 'CASCADE',
+                related_name: Optional[str] = None, **kwargs):
         super().__init__(field_type='INTEGER', **kwargs)
         self.to = to  # This is the related model class
         self.on_delete = on_delete  # Specifies the behavior when the referenced row is deleted
-        # PostgreSQL usually uses INTEGER or BIGINT for foreign key references.
-
+        self.related_name = related_name  
+        
 class FloatField(Field):
     def __init__(self, **kwargs):
         super().__init__(field_type='REAL', **kwargs)  # PostgreSQL uses REAL for floating point numbers

--- a/abarorm/fields/sqlite.py
+++ b/abarorm/fields/sqlite.py
@@ -40,11 +40,13 @@ class TimeField(Field):
         super().__init__(field_type='TIME', **kwargs)
 
 class ForeignKey(Field):
-    def __init__(self, to: Type['BaseModel'], on_delete: str = 'CASCADE', **kwargs):
+    def __init__(self, to: Type['BaseModel'], on_delete: str = 'CASCADE',
+                 related_name: Optional[str] = None, **kwargs):
         super().__init__(field_type='INTEGER', **kwargs)
-        self.to = to  # This is the related model class
-        self.on_delete = on_delete  # Specifies the behavior when the referenced row is deleted
-        
+        self.to = to  
+        self.on_delete = on_delete 
+        self.related_name = related_name  
+
 class FloatField(Field):
     def __init__(self, **kwargs):
         super().__init__(field_type='FLOAT', **kwargs)

--- a/abarorm/sqlite.py
+++ b/abarorm/sqlite.py
@@ -3,16 +3,55 @@ from typing import List, Optional, Dict
 import datetime
 from .fields.sqlite import Field, DateTimeField, DecimalField, TimeField, DateField, CharField, ForeignKey
 
+
+class RelatedManager:
+    """Manager for handling related objects from ForeignKey."""
+    def __init__(self, model, field_name, instance_id):
+        self.model = model
+        self.field_name = field_name
+        self.instance_id = instance_id
+
+    def all(self):
+        return self.model.filter(**{self.field_name: self.instance_id})
+
+    def filter(self, **kwargs):
+        return self.model.filter(**{self.field_name: self.instance_id, **kwargs})
+
+    def first(self):
+        qs = self.all()
+        return qs.first() if qs.exists() else None
+
+    def last(self):
+        qs = self.all()
+        return qs.last() if qs.exists() else None
+
+    def count(self):
+        return self.all().count()
+    
+    def to_dict(self) -> List[Dict]:
+            """Returns the results as a list of dictionaries."""
+            return [obj.__dict__ for obj in self.results]
+        
 class ModelMeta(type):
     def __new__(cls, name, bases, dct):
         new_cls = super().__new__(cls, name, bases, dct)
-        if not hasattr(new_cls.Meta, 'table_name') or not new_cls.Meta.table_name:
-            new_cls.table_name = name.lower()  # Automatically set table_name from model class name
-        else:
-            new_cls.table_name = new_cls.Meta.table_name  # Override with Meta.table_name if provided
 
+        if not hasattr(new_cls.Meta, 'table_name') or not new_cls.Meta.table_name:
+            new_cls.table_name = name.lower()
+        else:
+            new_cls.table_name = new_cls.Meta.table_name
+
+        # Related fields
+        for attr, field in dct.items():
+            if isinstance(field, ForeignKey) and field.related_name:
+                def related_manager(self, _model=new_cls, _field=attr):
+                    return RelatedManager(_model, _field, self.id)
+                setattr(field.to, field.related_name, property(related_manager))
+
+        # Create table if db_config exists
         if hasattr(new_cls.Meta, 'db_config') and new_cls.Meta.db_config:
-            new_cls.create_table()  # Automatically create the table if db_config is present
+            new_cls.create_table()
+
         return new_cls
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys
 
-__version__ = '5.3.1'
+__version__ = '5.4.0'
 
 
 if '--version' in sys.argv:


### PR DESCRIPTION
# Pull Request - AbarORM 5.4.0

## Summary
This PR introduces major improvements to PostgreSQL support and adds full support for the `related_name` attribute in ForeignKey fields. Related QuerySets now work seamlessly with all standard QuerySet operations.

## Changes
- Improved PostgreSQL connection handling.
- Automatic creation of PostgreSQL databases if they do not exist.
- Added support for `related_name` in ForeignKey fields.
- Related records accessed via `related_name` now return fully functional QuerySets.
- QuerySet methods like `filter`, `first`, `last`, `count`, `to_dict`, and pagination work on related QuerySets.

## Notes
These changes improve usability when working with related models and simplify database setup and management for PostgreSQL users.
